### PR TITLE
issue-9: Remove WIP from `wheelbarrow` page

### DIFF
--- a/_pages/wheelbarrow.html
+++ b/_pages/wheelbarrow.html
@@ -7,9 +7,6 @@ top-img: /assets/images/wheelbarrow/7.jpg
 
 <div class="chapters">
     <div class="sections">
-        <div class="title">
-            (Work in Progress)
-        </div>
         <img src="/assets/images/wheelbarrow/1.png" width="75%" style="border-radius: 1em;">
 
         <div class="section-paragraph">


### PR DESCRIPTION
Closes #9 

PR Highlights:
- Removed WIP from `wheelbarrow` page